### PR TITLE
Cleans dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
 geopandas>=0.9
-fiona
-pandas
-shapely
 requests
 appdirs
-pip
-numpy
-rtree


### PR DESCRIPTION
This PR simply removes dependencies that are not needed:

By requiring GeoPandas, NumPy, Pandas and Shapely are already required.

RTree, Fiona and PiP are not really dependencies of Pygris, and since Fiona is being deprecated, it has started to create problems when installing on Python 3.12+