### PR TITLE
Document modules with mkdocstrings

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,3 +1,15 @@
 # Reference
 
-Full API reference coming soon!
+::: pygris.data
+::: pygris.enumeration_units
+::: pygris.geocode
+::: pygris.geometry
+::: pygris.helpers
+::: pygris.internal_data
+::: pygris.legislative
+::: pygris.metro_areas
+::: pygris.national
+::: pygris.native
+::: pygris.transportation
+::: pygris.utils
+::: pygris.water

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,5 +18,5 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          selection:
+          options:
             docstring_style: numpy


### PR DESCRIPTION
Hi, this uses the latest mkdocstrings to document the modules in this package.

I don't see either automated builds for your docs or pinned versions of mkdocstrings. 