### PR TITLE
add conda-forge to README & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ pip install pygris
 # pip install pygris[explore]
 ```
 
+Or via `conda-forge` with:
+
+```bash
+conda install pygris
+
+# For optional dependencies to support interactive examples in the documentation:
+# conda install "pygris[explore]"
+```
+
 Alternatively, install the development version from GitHub:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,15 @@ pip install pygris
 # pip install pygris[explore]
 ```
 
+Or via `conda-forge` with:
+
+```bash
+conda install pygris
+
+# For optional dependencies to support interactive examples in the documentation:
+# conda install "pygris[explore]"
+```
+
 Alternatively, install the development version from GitHub:
 
 ```bash


### PR DESCRIPTION
This is a small PR following #11 that adds installation instructions from `conda-forge` to the documentation.